### PR TITLE
feat: build and deploy from circleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,49 @@
+version: 2
+jobs:
+  build:
+    docker:
+      - image: circleci/node:10.15.1-browsers
+        environment:
+          NO_SANDBOX: true
+    steps:
+      - checkout
+      - run:
+          command: yarn
+      - run:
+          command: yarn build
+      - persist_to_workspace:
+          root: .
+          paths:
+            - dist
+
+  deploy:
+    docker:
+      - image: olizilla/ipfs-dns-deploy:1.1
+        environment:
+          DOMAIN: camp.ipfs.io
+          BUILD_DIR: dist
+    steps:
+      - attach_workspace:
+          at: /tmp/workspace
+      - run:
+          name: Deploy website to IPFS
+          command: |
+            pin_name="$DOMAIN build $CIRCLE_BUILD_NUMBER"
+
+            hash=$(pin-to-cluster.sh "$pin_name" /tmp/workspace/$BUILD_DIR)
+
+            echo "Website added to IPFS: https://ipfs.io/ipfs/$hash"
+
+            if [ "$CIRCLE_BRANCH" == "master" ] ; then
+              dnslink-dnsimple -d $DOMAIN -r _dnslink -l /ipfs/$hash
+            fi
+
+workflows:
+  version: 2
+  build-deploy:
+    jobs:
+      - build
+      - deploy:
+          context: ipfs-dns-deploy
+          requires:
+            - build


### PR DESCRIPTION
to work this needs to live on ipfs-shipyard, or
someone with admin permissions on the protocol org to

- Set up a context called `ipfs-dns-deploy` on https://circleci.com/gh/protocol
- Add the vars listed here https://github.com/ipfs-shipyard/ipfs-dns-deploy#requirements
  - I (@olizilla) can give you the values to put in there.
- Invite github user @IPFSBot to the org.

with that in place, the site will get pinned to cluster and you'll get
an "added to ipfs" notification on your PRs with a link to the preview
site.

License: MIT
Signed-off-by: Oli Evans <oli@tableflip.io>