### PR TITLE
fix: dataLayer is not defined if GA is blocked

### DIFF
--- a/src/components/Analytics/index.js
+++ b/src/components/Analytics/index.js
@@ -10,7 +10,8 @@ export class Analytics extends React.Component {
   }
 
   gtag() {
-    dataLayer.push(arguments)
+    if (!window.dataLayer) return
+    window.dataLayer.push(arguments)
   }
 
   trackOutbound(href) {


### PR DESCRIPTION
this fixes a dev error in Firefox, I don't see it error in prod. firefox has recently enabled more aggressive tracking protection, so ga wont load for some users, and dataLayer wont be defined, so guard against it here.

<img width="1341" alt="screenshot 2019-02-28 at 17 07 32" src="https://user-images.githubusercontent.com/58871/53584608-e3c70d00-3b7b-11e9-9347-dbf6f55d3d1d.png">


License: MIT
Signed-off-by: Oli Evans <oli@tableflip.io>