### PR TITLE
fix: ensure `to` property is always present

### DIFF
--- a/src/components/Router/index.tsx
+++ b/src/components/Router/index.tsx
@@ -15,7 +15,7 @@ export type LinkProps<T> = RouterLinkProps<T> & {
 
 // router link that handles href and to props
 export const Link: React.FC<LinkProps<HTMLAnchorElement>> = ({
-  to,
+  to = '',
   href,
   children,
   ...props


### PR DESCRIPTION
Patch to ensure an empty `href` can be accepted during markdown transforms